### PR TITLE
add tractseg step

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,26 @@ p_l^\text{(normalized)} = \sum_{m=-l}^{l} (c^m_l/c^0_0)^2 = p_l/p_0
 ```
 This is a type of normalization because the integral of a FOD over the sphere is proportional to $c^0_0$.
 
+## Compute tractography with segmentation and compute TOMs
+
+This step is not part of the NODDI-TBSS pipeline, but is included here for our convenience because we needed it for something unrelated.
+This step requires MRtrix3.
+The method has been ported over from [this script](https://github.com/brain-microstructure-exploration-tools/abcd-registration-experiments/blob/7e78678297f4eeba317418e6c313260ca642227a/evaluation_framework/single_subject_tractography.py).
+
+Install TractSeg (it can go into the main python environment being used for most of these steps):
+```sh
+pip install TractSeg
+```
+
+Compute peaks:
+```
+mkdir fod_peaks/
+./sh2peaks_batch.sh csd_output/ hdbet_output/ fod_peaks/
+```
+
+
+
+
 ## Generate a population template
 
 Here we use MRtrix3 to generate a FOD population template. Then:

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ p_l^\text{(normalized)} = \sum_{m=-l}^{l} (c^m_l/c^0_0)^2 = p_l/p_0
 ```
 This is a type of normalization because the integral of a FOD over the sphere is proportional to $c^0_0$.
 
-## Compute tractography with segmentation and compute TOMs
+## Compute TOMs and tracts
 
 This step is not part of the NODDI-TBSS pipeline, but is included here for our convenience because we needed it for something unrelated.
 This step requires MRtrix3.
@@ -211,6 +211,11 @@ mkdir fod_peaks/
 ./sh2peaks_batch.sh csd_output/ hdbet_output/ fod_peaks/
 ```
 
+Run TractSeg:
+```sh
+mkdir tractseg_output/
+./tractseg.sh fod_peaks/ hdbet_output/ tractseg_output/
+```
 
 
 

--- a/sh2peaks_batch.sh
+++ b/sh2peaks_batch.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+if [[ $# -ne 3 ]]; then
+  echo "Usage: ./sh2peaks_batch.sh <CSD_OUTPUT_PATH> <MASKS_PATH> <DESTINATION_PATH>"
+  echo "  where CSD_OUTPUT_PATH is the path to the folder into which CSD output was placed"
+  echo "  and MASKS_PATH is the folder in which you saved the brain masks"
+  echo "  and DESTINATION_PATH is the folder in which you want to save peaks."
+  exit
+fi
+
+CSD_OUTPUT_PATH=$1
+MASKS_PATH=$2
+PEAKS_PATH=$3
+
+FOD_PATH=$CSD_OUTPUT_PATH/fod
+
+if [ ! -d "$FOD_PATH" ]; then
+    echo "FOD directory not found"
+    exit 1
+fi
+
+mkdir -p $PEAKS_PATH
+
+# Estimate a response function for each image
+for FOD in "$FOD_PATH"/*_fod.nii.gz; do
+  BASENAME=$(basename $FOD _fod.nii.gz)
+  MASK=$MASKS_PATH/${BASENAME}_mask.nii.gz
+  OUTPUT="$PEAKS_PATH"/${BASENAME}_peaks.nii.gz
+  if [ -f "$OUTPUT" ]; then
+    echo "Skipping ${BASENAME} because this file already exists: ${OUTPUT}"
+    continue
+  fi
+  sh2peaks $FOD $OUTPUT -mask $MASK
+done

--- a/tractseg.sh
+++ b/tractseg.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -e
+
+if [[ $# -ne 3 ]]; then
+  echo "Usage: ./sh2peaks_batch.sh <PEAKS_PATH> <MASKS_PATH> <TRACTSEG_OUTPUT_PATH>"
+  echo "  where PEAKS_PATH is the path to the folder into which FOD peaks were saved"
+  echo "  and MASKS_PATH is the folder in which you saved the brain masks"
+  echo "  and TRACTSEG_OUTPUT_PATH is the folder to save output into."
+  exit
+fi
+
+PEAKS_PATH=$1
+MASKS_PATH=$2
+TRACTSEG_OUTPUT_PATH=$3
+
+if [ ! -d "$PEAKS_PATH" ]; then
+    echo "Peaks directory not found"
+    exit 1
+fi
+
+mkdir -p $TRACTSEG_OUTPUT_PATH
+
+# Estimate a response function for each image
+for PEAKS in "$PEAKS_PATH"/*_peaks.nii.gz; do
+  BASENAME=$(basename $PEAKS _peaks.nii.gz)
+  MASK=$MASKS_PATH/${BASENAME}_mask.nii.gz
+  OUTPUT_DIR="$TRACTSEG_OUTPUT_PATH"/${BASENAME}/
+  mkdir -p "$OUTPUT_DIR"
+
+  # tractseg needs us to compute three things before doing tractography: tract segmentations,
+  # bundle segmentations, and TOMs (tract orientation maps).
+  # after getting those three things then from those it performs tractography.
+
+  TRACT_SEGS="$OUTPUT_DIR/bundle_segmentations"
+  END_SEGS="$OUTPUT_DIR/endings_segmentations"
+  TOMS="$OUTPUT_DIR/TOM"
+  TRACTS="$OUTPUT_DIR/TOM_trackings"
+
+  if [ -d $TRACT_SEGS ]; then
+    echo "Bundle segmentations already exist at {$TRACT_SEGS}, skipping tract_segmentation."
+  else
+    TractSeg --output_type tract_segmentation -i "$PEAKS" -o "$OUTPUT_DIR" --brain_mask "$MASK"
+  fi
+
+  if [ -d $END_SEGS ]; then
+    echo "Ending segmentations already exist at {$END_SEGS}, skipping endings_segmentation."
+  else
+    TractSeg --output_type endings_segmentation -i "$PEAKS" -o "$OUTPUT_DIR" --brain_mask "$MASK"
+  fi
+
+  if [ -d $TOMS ]; then
+    echo "TOMs already exist at {$TOMS}, skipping TOM computation."
+  else
+    TractSeg --output_type TOM -i "$PEAKS" -o "$OUTPUT_DIR" --brain_mask "$MASK"
+  fi
+
+  if [ -d $TRACTS ]; then
+    echo "Tracts already exist at {$TRACTS}, skipping tractography."
+  else
+    Tracking --algorithm prob -i "$PEAKS" -o "$OUTPUT_DIR"
+  fi
+
+  echo -e "\n\n===== Done processing $BASENAME =====\n\n"
+done


### PR DESCRIPTION
This step is not part of the NODDI-TBSS pipeline, but is included here for our convenience because we needed it for our registration model evaluation. The method is being ported over from [this script](https://github.com/brain-microstructure-exploration-tools/abcd-registration-experiments/blob/7e78678297f4eeba317418e6c313260ca642227a/evaluation_framework/single_subject_tractography.py).

Closes #24 